### PR TITLE
Fix adminv2 FS/TS host switching to main server hosts

### DIFF
--- a/public/app/popup.js
+++ b/public/app/popup.js
@@ -44,9 +44,19 @@ function persistStoredNumber(prefix, rawValue) {
   }
 }
 
+function is1stdibsDomain(hostname) {
+  return hostname === "1stdibs.com" || hostname.endsWith(".1stdibs.com");
+}
+
 function makeLink(urlParts, serverName, realName) {
   if (!urlParts) {
     return "https://www.1stdibs.com/";
+  }
+
+  if (!is1stdibsDomain(urlParts.hostname)) {
+    const fallbackHost =
+      realName === "PROD" ? "www.1stdibs.com" : `${serverName}.1stdibs.com`;
+    return `https://${fallbackHost}/`;
   }
 
   const hostParts = urlParts.host.split(".");
@@ -107,6 +117,10 @@ function makeNumberedServerLink(urlParts, prefix, numberValue) {
     : numberedPrefix;
   const host = `${hostPrefix}.${prefix}.1stdibs.com`;
   if (!urlParts) {
+    return `https://${host}/`;
+  }
+
+  if (!is1stdibsDomain(urlParts.hostname)) {
     return `https://${host}/`;
   }
 

--- a/public/app/popup.js
+++ b/public/app/popup.js
@@ -49,33 +49,30 @@ function makeLink(urlParts, serverName, realName) {
     return "https://www.1stdibs.com/";
   }
 
-  let newHost = "";
   const hostParts = urlParts.host.split(".");
-  const isAdminV2Host =
-    hostParts[0] === "adminv2" || hostParts[0].startsWith("adminv2-");
+  const isAdminV2Host = /^adminv2(?:[.-]|$)/.test(hostParts[0]);
+
+  // Normalize all adminv2 entry hosts (adminv2.*, adminv2-*) to dot format.
+  if (isAdminV2Host) {
+    const normalizedHost =
+      realName === "PROD"
+        ? "adminv2.1stdibs.com"
+        : `adminv2.${serverName}.1stdibs.com`;
+    return `${urlParts.protocol}//${normalizedHost}${urlParts.pathname}${urlParts.search}`;
+  }
+
+  let newHost = "";
 
   switch (hostParts.length) {
     case 3:
-      if (isAdminV2Host) {
-        if (realName === "PROD") {
-          newHost = "adminv2.1stdibs.com";
-        } else {
-          newHost = `adminv2.${serverName}.1stdibs.com`;
-        }
-      } else if (hostParts[1] === "1stdibs") {
+      if (hostParts[1] === "1stdibs") {
         newHost = `${serverName}.1stdibs.com`;
       } else {
         newHost = urlParts.host;
       }
       break;
     case 4:
-      if (isAdminV2Host) {
-        if (realName === "PROD") {
-          newHost = "adminv2.1stdibs.com";
-        } else {
-          newHost = `adminv2.${serverName}.1stdibs.com`;
-        }
-      } else if (hostParts[1] === "intranet") {
+      if (hostParts[1] === "intranet") {
         newHost = `${serverName}.1stdibs.com`;
       } else {
         newHost = urlParts.host;

--- a/public/app/popup.js
+++ b/public/app/popup.js
@@ -51,10 +51,12 @@ function makeLink(urlParts, serverName, realName) {
 
   let newHost = "";
   const hostParts = urlParts.host.split(".");
+  const isAdminV2Host =
+    hostParts[0] === "adminv2" || hostParts[0].startsWith("adminv2-");
 
   switch (hostParts.length) {
     case 3:
-      if (hostParts[0] === "adminv2") {
+      if (isAdminV2Host) {
         if (realName === "PROD") {
           newHost = "adminv2.1stdibs.com";
         } else {
@@ -67,7 +69,7 @@ function makeLink(urlParts, serverName, realName) {
       }
       break;
     case 4:
-      if (hostParts[0] === "adminv2") {
+      if (isAdminV2Host) {
         if (realName === "PROD") {
           newHost = "adminv2.1stdibs.com";
         } else {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix host rewriting when starting from `adminv2-fs{n}.fs.1stdibs.com` or `adminv2-ts{n}.ts.1stdibs.com`
- treat `adminv2-*` hosts as adminv2 context in main server switching logic
- ensure switching to non-FS/TS main servers converts the host format to dotted adminv2 style (for example: `adminv2.qa.1stdibs.com`)

## Validation
- verified the change in `public/app/popup.js` (`makeLink`)
- manually confirmed the host detection now handles both `adminv2` and `adminv2-*` prefixes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10220261-f73b-4988-a16d-df87e4f41b0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10220261-f73b-4988-a16d-df87e4f41b0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

